### PR TITLE
readme.md: fix Lri references

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,10 +1,9 @@
 DefaultKeyBindings.dict file (`~/Library/KeyBindings/DefaultKeyBindings.dict`) for Mac OS X, created by [Brett Terpstra][] and based heavily on work done by [Lri][lrikeys].
 Please note that these bindings won't work in all applications: TextWrangler and TextMate, for example, override these with their own settings.
-See Lri's [gists][lrigists] and [website][lriweb] for more coding madness.
+See Lri's [website][lriweb] for more coding madness.
 
-[lrikeys]: http://www.cs.helsinki.fi/u/lranta/keybindings/
-[lriweb]: http://www.cs.helsinki.fi/u/lranta/
-[lrigists]: https://gist.github.com/Lri
+[lrikeys]: http://osxnotes.net/keybindings.html
+[lriweb]: http://osxnotes.net/
 [brett terpstra]: http://brettterpstra.com
 
 **Installation:** Copy the DefaultKeyBindings.dict file to the `~/Library/KeyBindings/` directory (create `KeyBindings` if it doesn't already exist). 


### PR DESCRIPTION
Lri [doesn’t have any gists](https://gist.github.com/Lri) anymore, and the website links are down.

With [The Internet Archive](https://archive.org/), if we [go back far enough with the link](http://web.archive.org/web/20110815000000*/http://www.cs.helsinki.fi/u/lranta/keybindings/) (November 10<sup>th</sup> 2011 is last one that works correctly), we see [it redirects](http://web.archive.org/web/20111110094750/http://www.cs.helsinki.fi/u/lranta/keybindings) to [an uncrawlable link](http://web.archive.org/web/20111110094750/http://lri.me/keybindings) that itself redirects the new one in this PR.