### PR TITLE
document_keybindings.rb: substitute for the correct CTRL character

### DIFF
--- a/document_keybindings.rb
+++ b/document_keybindings.rb
@@ -67,7 +67,7 @@ def e_sh(str)
 end
 
 def translate_command(str)
-  str = str.gsub(/~/,'⌥').gsub(/@/,'⌘').gsub(/\$/,'⇧')
+  str = str.gsub(/~/,'⌥').gsub(/@/,'⌘').gsub(/\$/,'⇧').gsub(/\^/,'⌃')
   str = str.gsub('\UF700','↑').gsub('\UF701','↓').gsub('\UF703','→').gsub('\UF702','←')
   str = str.gsub('\U0009','⇥').gsub('\U000D','↩').gsub('\U001B','⎋').gsub('\U000A','␍')
   str = str.gsub('\UF728','⌦').gsub('\177','⌫')


### PR DESCRIPTION
It may look like the same character at first glance, but it is not. If you paste `⌃^` onto google’s search bar, for example, the difference is quite apparent.
![](http://i.imgur.com/EhbK3X7.png)